### PR TITLE
Fix code scanning alert no. 2: Unsafe HTML constructed from library input

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   },
   "dependencies": {
     "laravel-elixir": "^4.0.0",
-    "bootstrap-sass": "^3.0.0"
+    "bootstrap-sass": "^3.0.0",
+    "dompurify": "^3.2.0"
   }
 }

--- a/public/packages/nestable/jquery.nestable.js
+++ b/public/packages/nestable/jquery.nestable.js
@@ -2,6 +2,7 @@
  * Nestable jQuery Plugin - Copyright (c) 2012 David Bushell - http://dbushell.com/
  * Dual-licensed under the BSD or MIT licenses
  */
+import DOMPurify from 'dompurify';
 ;(function($, window, document, undefined)
 {
     var hasTouch = 'ontouchstart' in document;
@@ -447,7 +448,7 @@
                     this.unsetParent(parent.parent());
                 }
                 if (!this.dragRootEl.find(opt.itemNodeName).length) {
-                    this.dragRootEl.append('<div class="' + opt.emptyClass + '"/>');
+                    this.dragRootEl.append('<div class="' + DOMPurify.sanitize(opt.emptyClass) + '"/>');
                 }
                 // parent root list has changed
                 if (isNewRoot) {


### PR DESCRIPTION
Fixes [https://github.com/zayanit/cms/security/code-scanning/2](https://github.com/zayanit/cms/security/code-scanning/2)

To fix the problem, we need to ensure that any HTML content constructed from user input is properly sanitized or escaped to prevent XSS attacks. In this case, we should sanitize the `opt.emptyClass` value before using it to construct HTML. We can use a library like `DOMPurify` to sanitize the input.

1. Install the `DOMPurify` library.
2. Import `DOMPurify` in the file.
3. Sanitize the `opt.emptyClass` value before using it to construct HTML.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
