### PR TITLE
Fix Dependabot security alerts: upgrade dev deps and framework

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -2,13 +2,13 @@
 
 namespace App\Exceptions;
 
-use Exception;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
-use Illuminate\Foundation\Validation\ValidationException;
+use Illuminate\Validation\ValidationException;
 use Litepie\Support\Facades\Theme;
 use Symfony\Component\HttpKernel\Exception\HttpException;
+use Throwable;
 
 class Handler extends ExceptionHandler
 {
@@ -24,32 +24,13 @@ class Handler extends ExceptionHandler
         ValidationException::class,
     ];
 
-    /**
-     * Report or log an exception.
-     *
-     * This is a great spot to send exceptions to Sentry, Bugsnag, etc.
-     *
-     * @param \Exception $e
-     *
-     * @return void
-     */
-    public function report(Exception $e)
+    public function report(Throwable $e)
     {
-
         return parent::report($e);
     }
 
-    /**
-     * Render an exception into an HTTP response.
-     *
-     * @param \Illuminate\Http\Request $request
-     * @param \Exception               $e
-     *
-     * @return \Illuminate\Http\Response
-     */
-    public function render($request, Exception $e)
+    public function render($request, Throwable $e)
     {
-
         return parent::render($request, $e);
     }
 

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -38,5 +38,5 @@ Route::group(['middleware' => 'web'], function () {
     Route::get('client/password', 'ClientWebController@getPassword');
     Route::post('client/password', 'ClientWebController@postPassword');
 
-    Route::auth();
+    Auth::routes();
 });

--- a/composer.json
+++ b/composer.json
@@ -5,21 +5,16 @@
     "license": "MIT",
     "type": "cms",
     "require": {
-        "php": ">=5.5.9",
-        "laravel/framework": "6.20.45",
-        "lavalite/framework": "1.2.*",
-        "lavalite/page": "4.1.*",
-        "lavalite/settings": "4.1.*",
-        "lavalite/task": "4.1.*",
-        "lavalite/message": "4.1.*",
-        "lavalite/calendar": "4.1.*"
+        "php": ">=7.2.5",
+        "laravel/framework": "^7.30",
+        "lavalite/framework": "^7.0"
     },
     "require-dev": {
         "fzaninotto/faker": "~1.4",
-        "mockery/mockery": "0.9.*",
-        "phpunit/phpunit": "~4.0",
-        "symfony/css-selector": "2.8.*|3.0.*",
-        "symfony/dom-crawler": "2.8.*|3.0.*"
+        "mockery/mockery": "^1.4",
+        "phpunit/phpunit": "^9.6",
+        "symfony/css-selector": "^4.4|^5.4|^6.4",
+        "symfony/dom-crawler": "^4.4|^5.4|^6.4"
     },
     "autoload": {
         "classmap": [

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -3,22 +3,18 @@
          backupStaticAttributes="false"
          bootstrap="bootstrap/autoload.php"
          colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
          processIsolation="false"
-         stopOnFailure="false"
-         syntaxCheck="false">
+         stopOnFailure="false">
     <testsuites>
         <testsuite name="Application Test Suite">
             <directory>./tests/</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist>
+    <coverage>
+        <include>
             <directory suffix=".php">app/</directory>
-        </whitelist>
-    </filter>
+        </include>
+    </coverage>
     <php>
         <env name="APP_ENV" value="testing"/>
         <env name="CACHE_DRIVER" value="array"/>


### PR DESCRIPTION
## Summary

- **Fixes alert #18** (High): `phpunit/phpunit` unsafe deserialization — upgraded from `~4.0` to `^9.6` (now 9.6.35)
- **Fixes alert #20** (Low): `symfony/dom-crawler` XXE — upgraded from `2.8.*|3.0.*` to `^4.4|^5.4|^6.4` (now 6.4.40); same for `symfony/css-selector`
- **Fixes broken constraint**: `lavalite/framework 1.2.*` did not exist on Packagist — corrected to `^7.0`
- **Upgrades Laravel**: `laravel/framework` unpinned from exact EOL version `6.20.45` to `^7.30` so installs are no longer blocked by Packagist security policy
- **Removes 5 uninstallable packages**: `lavalite/calendar`, `lavalite/message`, `lavalite/page`, `lavalite/settings`, `lavalite/task` — their GitHub repos have been deleted; every version across every dist/source URL returns 404
- **Laravel 7 compatibility fixes**: `Route::auth()` → `Auth::routes()`; `Handler::report/render` signatures updated from `Exception` to `Throwable`; `phpunit.xml` cleaned of removed attributes

## Outstanding issues (not fixable in this PR)

Alerts **#17, #21, #22** (Laravel CRLF injection, file validation bypass, signed URL confusion) affect **all Laravel versions below 12.61.1**. The patched range requires jumping from Laravel 7 to Laravel 12, which spans 5 major versions and requires a full application migration. This is tracked separately.

Two additional `league/commonmark` advisories were discovered as transitive dependencies of `laravel/framework`. These will also be resolved when Laravel is upgraded to 12.x.

## Test plan

- [x] `composer install` succeeds (was completely broken before — blocked by security policy + broken `1.2.*` constraint)
- [x] `php artisan clear-compiled` runs without fatal errors
- [x] `vendor/bin/phpunit` runs cleanly (PHPUnit 9.6.35, no config warnings)
- [x] `composer audit` confirms phpunit and symfony/dom-crawler advisories are gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)